### PR TITLE
Make xacro Cmake calls conditional on CMake argument

### DIFF
--- a/vrx_gazebo/CMakeLists.txt
+++ b/vrx_gazebo/CMakeLists.txt
@@ -345,25 +345,26 @@ install(PROGRAMS scripts/spawn_wamv.bash
   DESTINATION lib/${PROJECT_NAME})
 
 # Generate world files from xacro and install
-xacro_add_files(
-  worlds/dock.world.xacro
-  worlds/example_course.world.xacro
-  worlds/example_course_2019.world.xacro
-  worlds/gymkhana.world.xacro
-  worlds/navigation_task.world.xacro
-  worlds/ocean.world.xacro
-  worlds/perception_task.world.xacro
-  worlds/scan_and_dock.world.xacro
-  worlds/scan_dock_deliver.world.xacro
-  worlds/sandisland.world.xacro
-  worlds/stationkeeping_task.world.xacro
-  worlds/sydneyregatta.world.xacro
-  worlds/wayfinding_task.world.xacro
-  worlds/wildlife_task.world.xacro
-  worlds/wind_test.world.xacro
-  INSTALL DESTINATION worlds
-)
-
+if(ADD_XACRO)
+  xacro_add_files(
+    worlds/dock.world.xacro
+    worlds/example_course.world.xacro
+    worlds/example_course_2019.world.xacro
+    worlds/gymkhana.world.xacro
+    worlds/navigation_task.world.xacro
+    worlds/ocean.world.xacro
+    worlds/perception_task.world.xacro
+    worlds/scan_and_dock.world.xacro
+    worlds/scan_dock_deliver.world.xacro
+    worlds/sandisland.world.xacro
+    worlds/stationkeeping_task.world.xacro
+    worlds/sydneyregatta.world.xacro
+    worlds/wayfinding_task.world.xacro
+    worlds/wildlife_task.world.xacro
+    worlds/wind_test.world.xacro
+    INSTALL DESTINATION worlds
+  )
+endif()
 
 if(AMENT_ENABLE_TESTING)
   find_package(ament_cmake_gtest REQUIRED)

--- a/wamv_description/CMakeLists.txt
+++ b/wamv_description/CMakeLists.txt
@@ -3,10 +3,12 @@ project(wamv_description)
 find_package(ament_cmake REQUIRED)
 find_package(xacro REQUIRED)
 
-xacro_add_files(
-  urdf/wamv_base.urdf.xacro
-    INSTALL DESTINATION urdf
-)
+if(ADD_XACRO)
+  xacro_add_files(
+    urdf/wamv_base.urdf.xacro
+      INSTALL DESTINATION urdf
+  )
+endif()
 
 install(DIRECTORY models/
   DESTINATION share/${PROJECT_NAME}/models)

--- a/wamv_gazebo/CMakeLists.txt
+++ b/wamv_gazebo/CMakeLists.txt
@@ -8,10 +8,12 @@ find_package(usv_gazebo_plugins REQUIRED)
 find_package(xacro REQUIRED)
 
 # Generate urdf files from xacro and install
-xacro_add_files(
-  urdf/wamv_gazebo.urdf.xacro
-  INSTALL DESTINATION urdf
-)
+if(ADD_XACRO)
+  xacro_add_files(
+    urdf/wamv_gazebo.urdf.xacro
+    INSTALL DESTINATION urdf
+  )
+endif()
 
 # Install meshes and textures
 install(DIRECTORY models/

--- a/wave_gazebo/CMakeLists.txt
+++ b/wave_gazebo/CMakeLists.txt
@@ -38,12 +38,13 @@ add_custom_target(model_erb_generation ALL
 )
 
 # Generate world files from xacro and install
-xacro_add_files(
-  worlds/ocean.world.xacro
-  worlds/ocean_buoys.world.xacro
-  worlds/ocean_wamv.world.xacro
-  INSTALL DESTINATION worlds
-)
-
+if(ADD_XACRO)
+  xacro_add_files(
+    worlds/ocean.world.xacro
+    worlds/ocean_buoys.world.xacro
+    worlds/ocean_wamv.world.xacro
+    INSTALL DESTINATION worlds
+  )
+endif()
 
 ament_package()


### PR DESCRIPTION
This makes the workaround of commenting out xacro commands a little easier. So now it's build as before, then build with `-DADD_XACRO=1 --no-warn-unused-cli`.

The full build might look something like this:
```bash
colcon build
source install/setup.sh
colcon build --cmake-args "-DADD_XACRO=1" --cmake-args "--no-warn-unused-cli"
```